### PR TITLE
Fixed CI & solved regressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 # Test stuff
 .tox
 .xprocess/
+.pytest_cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-Nothing here yet.
+* Fixed CI & solved regressions by upgrading of `pytest-xprocess` & `Markdown` libraries.
 
 ## v0.3.0 (2019-10-05)
 

--- a/Makefile
+++ b/Makefile
@@ -29,4 +29,4 @@ clean:
 # Cleanup pytest utilities
 xkill:
 	$(VENV)pytest --xkill
-	rm -Rf .xprocess
+	rm -Rf .pytest_cache/d/.xprocess

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,8 +31,7 @@ packages = find:
 include_package_data = true
 python_requires = >= 3.6
 install_requires =
-    # Because of py-gfm incompatibility with 3.x series
-	markdown<3.0
+    markdown
     py-gfm
     python-slugify
     loguru
@@ -52,6 +51,7 @@ dev =
     black
     isort
     flake8
+maintain =
     # packaging
     twine
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,8 +15,11 @@ def http_server(xprocess):
         pattern = "Serving"
         args = ["python", f"{executable_dir}/cli.py", example_dir]
 
-    server = xprocess.ensure("server-default", Starter)
-    return server
+    _ = xprocess.ensure("server-default", Starter)
+    info = xprocess.getinfo("server-default")
+    assert info.isrunning()
+    yield info
+    xprocess.getinfo("server-default").terminate()
 
 
 @pytest.fixture
@@ -33,5 +36,8 @@ def http_server_custom_style(xprocess):
             "8081",
         ]
 
-    server = xprocess.ensure("server-custom-css", Starter)
-    return server
+    _ = xprocess.ensure("server-custom-css", Starter)
+    info = xprocess.getinfo("server-custom-css")
+    assert info.isrunning()
+    yield info
+    xprocess.getinfo("server-custom-css").terminate()


### PR DESCRIPTION
* `Markdown` & `py-gfm` libraries incompatibilities are now solved, and the latest `py-gfm` version was incompatible with the previously-pinned version of Markdown.
* Had to upgrade `pytest-xprocess` & change its usage.